### PR TITLE
feat (networking): [dns resolution] cloud-init search backend domain using Azure provided DNS address

### DIFF
--- a/07-compute-infra.md
+++ b/07-compute-infra.md
@@ -27,7 +27,7 @@ Azure Application Gateway, for this reference implementation, is placed in the s
    export RESOURCEID_VMSS_FRONTEND_IAAS_BASELINE=$(az deployment sub show -n deploy-bu04a42-infra --query properties.outputs.frontendVmssResourceId.value -o tsv)
    export RESOURCEID_VMSS_BACKEND_IAAS_BASELINE=$(az deployment sub show -n deploy-bu04a42-infra --query properties.outputs.backendVmssResourceId.value -o tsv)
    export RESOURCEIDS_ALL_VIRTUAL_MACHINES_IAAS_BASELINE="$(az vm list --vmss ${RESOURCEID_VMSS_FRONTEND_IAAS_BASELINE} --query '[[].id]' -o tsv) $(az vm list --vmss ${RESOURCEID_VMSS_BACKEND_IAAS_BASELINE} --query '[[].id]' -o tsv)"
-   echo RESOURCEIDS_ALL_VIRTUAL_MACHINES_IAAS_BASELINE: $RESOURCEID_ALL_VIRTUAL_MACHINES_IAAS_BASELINE
+   echo RESOURCEIDS_ALL_VIRTUAL_MACHINES_IAAS_BASELINE: $RESOURCEIDS_ALL_VIRTUAL_MACHINES_IAAS_BASELINE
    ```
 
 1. Assign system managed identities to all virtual machines.

--- a/07-compute-infra.md
+++ b/07-compute-infra.md
@@ -18,11 +18,12 @@ Azure Application Gateway, for this reference implementation, is placed in the s
 
 ## Steps
 
-1. Convert your frontend cloud-init (users) file to Base64.
+1. Convert your frontend cloud-init (network configuration) file to Base64.
 
    ```bash
    FRONTEND_CLOUDINIT_BASE64=$(base64 workload-team/workload/frontendCloudInit.yml | tr -d '\n')
    ```
+
 1. Deploy the compute infrastructure ARM template.
 
    ```bash

--- a/07-compute-infra.md
+++ b/07-compute-infra.md
@@ -18,11 +18,16 @@ Azure Application Gateway, for this reference implementation, is placed in the s
 
 ## Steps
 
+1. Convert your frontend cloud-init (users) file to Base64.
+
+   ```bash
+   FRONTEND_CLOUDINIT_BASE64=$(base64 workload-team/workload/frontendCloudInit.yml | tr -d '\n')
+   ```
 1. Deploy the compute infrastructure ARM template.
 
    ```bash
    # [This takes about 18 minutes.]
-   az deployment sub create -l centralus -n deploy-bu04a42-infra -f workload-team/main.bicep -p targetVnetResourceId=${RESOURCEID_VNET_SPOKE_IAAS_BASELINE} location=${REGION_IAAS_BASELINE} appGatewayListenerCertificate=${APP_GATEWAY_LISTENER_CERTIFICATE_IAAS_BASELINE} vmssWildcardTlsPublicCertificate=${VMSS_WILDCARD_CERTIFICATE_BASE64_IAAS_BASELINE} vmssWildcardTlsPublicAndKeyCertificates=${VMSS_WILDCARD_CERT_PUBLIC_PRIVATE_KEYS_BASE64_IAAS_BASELINE} adminSecurityPrincipalObjectId=${OBJECTID_PRINCIPAL_COMPUTEADMIN_IAAS_BASELINE} adminSecurityPrincipalType=${COMPUTEADMIN_TYPE_IAAS_BASELINE}
+   az deployment sub create -l centralus -n deploy-bu04a42-infra -f workload-team/main.bicep -p targetVnetResourceId=${RESOURCEID_VNET_SPOKE_IAAS_BASELINE} location=${REGION_IAAS_BASELINE} appGatewayListenerCertificate=${APP_GATEWAY_LISTENER_CERTIFICATE_IAAS_BASELINE} vmssWildcardTlsPublicCertificate=${VMSS_WILDCARD_CERTIFICATE_BASE64_IAAS_BASELINE} vmssWildcardTlsPublicAndKeyCertificates=${VMSS_WILDCARD_CERT_PUBLIC_PRIVATE_KEYS_BASE64_IAAS_BASELINE} adminSecurityPrincipalObjectId=${OBJECTID_PRINCIPAL_COMPUTEADMIN_IAAS_BASELINE} adminSecurityPrincipalType=${COMPUTEADMIN_TYPE_IAAS_BASELINE} frontendCloudInitAsBase64="${FRONTEND_CLOUDINIT_BASE64}"
 
    export RESOURCEID_VMSS_FRONTEND_IAAS_BASELINE=$(az deployment sub show -n deploy-bu04a42-infra --query properties.outputs.frontendVmssResourceId.value -o tsv)
    export RESOURCEID_VMSS_BACKEND_IAAS_BASELINE=$(az deployment sub show -n deploy-bu04a42-infra --query properties.outputs.backendVmssResourceId.value -o tsv)

--- a/08-bootstrap-validation.md
+++ b/08-bootstrap-validation.md
@@ -86,7 +86,7 @@ A web server is enabled on both tiers of this deployment so that you can test en
       host azure.com && host backend-00.iaas-ingress.contoso.com
       ```
 
-     > Note: the Frontend VMs are configured to route-only backend-00.iaas-ingress.contoso.com via Azure Provided DNS (168.63.129.16). The rest of the DNS queries should be resolved via hub DNS IP.
+     > The frontend VMs are configured to resolve backend-00.iaas-ingress.contoso.com via Azure DNS (168.63.129.16). All other DNS queries are resolved by the virtual network provided (DHCP) DNS IP, which is the Azure Firewall DNS proxy in the hub.
 
    1. Kill the background proccess for capturing your network traffic
 
@@ -101,7 +101,7 @@ A web server is enabled on both tiers of this deployment so that you can test en
       tcpdump -tnr /tmp/dns.pcap | grep -E 'backend-00.iaas-ingress.contoso.com|azure.com'
       ```
 
-      > Note: the results should reflect that your backend VM and azure FQDNs are resolved using diffrent DNS IPs.
+      > The results should reflect that your backend FQDN and other FQDNs are resolved using different DNS IPs.
 
       ```outcome
       IP 10.240.0.4.60236 > 10.200.0.4.53: 3399+ [1au] A? azure.com. (38)

--- a/workload-team/app-infra-stamp.bicep
+++ b/workload-team/app-infra-stamp.bicep
@@ -40,6 +40,10 @@ param adminSecurityPrincipalObjectId string
 ])
 param adminSecurityPrincipalType string
 
+@description('A cloud init file (starting with #cloud-config) as a base 64 encoded string used to perform image customization on the jump box VMs. Used for user-management in this context.')
+@minLength(100)
+param frontendCloudInitAsBase64 string
+
 /*** VARIABLES ***/
 
 var agwName = 'agw-public-ingress'
@@ -272,6 +276,7 @@ resource vmssFrontend 'Microsoft.Compute/virtualMachineScaleSets@2023-03-01' = {
           }
         }
         adminUsername: defaultAdminUserName
+        customData: frontendCloudInitAsBase64
       }
       storageProfile: {
         osDisk: {

--- a/workload-team/app-infra-stamp.bicep
+++ b/workload-team/app-infra-stamp.bicep
@@ -498,7 +498,6 @@ resource vmssFrontend 'Microsoft.Compute/virtualMachineScaleSets@2023-03-01' = {
     peKv
     contosoPrivateDnsZone::vmssBackend
     contosoPrivateDnsZone::vnetlnk
-    contosoPrivateDnsZone::linkToHub
     grantAdminRbacAccessToRemoteIntoVMs
   ]
 }
@@ -781,7 +780,6 @@ resource vmssBackend 'Microsoft.Compute/virtualMachineScaleSets@2023-03-01' = {
     peKv
     contosoPrivateDnsZone::vmssBackend
     contosoPrivateDnsZone::vnetlnk
-    contosoPrivateDnsZone::linkToHub
     grantAdminRbacAccessToRemoteIntoVMs
   ]
 }
@@ -1052,21 +1050,6 @@ resource contosoPrivateDnsZone 'Microsoft.Network/privateDnsZones@2020-06-01' = 
       registrationEnabled: false
     }
   }
-
-  // TODO: This is going to need to be solved. As this is configured below, it will not work in this topology.
-  // THIS IS BEING DONE FOR SIMPLICTY IN DEPLOYMENT, NOT AS GUIDANCE.
-  // Normally a workload team wouldn't have this permission, and a DINE policy
-  // would have taken care of this step.
-  resource linkToHub 'virtualNetworkLinks' = {
-    name: 'to_${hubVirtualNetwork.name}'
-    location: 'global'
-    properties: {
-      virtualNetwork: {
-        id: hubVirtualNetwork.id
-      }
-      registrationEnabled: false
-    }
-  }
 }
 
 @description('The Azure Application Gateway that fronts our workload.')
@@ -1231,7 +1214,6 @@ resource workloadAppGateway 'Microsoft.Network/applicationGateways@2022-11-01' =
   }
   dependsOn: [
     contosoPrivateDnsZone::vnetlnk
-    contosoPrivateDnsZone::linkToHub
     contosoPrivateDnsZone::vmssBackend
     peKv
     peKeyVaultForAppGw::pdnszg

--- a/workload-team/app-infra-stamp.bicep
+++ b/workload-team/app-infra-stamp.bicep
@@ -90,12 +90,6 @@ resource workloadLogAnalytics 'Microsoft.OperationalInsights/workspaces@2022-10-
   name: 'log-${subComputeRgUniqueString}'
 }
 
-@description('TEMP: TODO: Provide a solution.')
-resource hubVirtualNetwork 'Microsoft.Network/virtualNetworks@2022-11-01' existing = {
-  scope: hubResourceGroup
-  name: 'vnet-${location}-hub'
-}
-
 @description('The existing public IP address to be used by Application Gateway for public ingress.')
 resource appGatewayPublicIp 'Microsoft.Network/publicIPAddresses@2022-11-01' existing = {
   scope: spokeResourceGroup

--- a/workload-team/app-infra-stamp.bicep
+++ b/workload-team/app-infra-stamp.bicep
@@ -633,10 +633,10 @@ resource vmssBackend 'Microsoft.Compute/virtualMachineScaleSets@2023-03-01' = {
         extensions: [
           {
             name: 'AADLogin'
-            provisionAfterExtensions: [
-              'CustomScript'
-            ]
             properties: {
+              provisionAfterExtensions: [
+                'CustomScript'
+              ]
               autoUpgradeMinorVersion: true
               publisher: 'Microsoft.Azure.ActiveDirectory'
               type: 'AADLoginForWindows'

--- a/workload-team/app-infra-stamp.bicep
+++ b/workload-team/app-infra-stamp.bicep
@@ -40,7 +40,7 @@ param adminSecurityPrincipalObjectId string
 ])
 param adminSecurityPrincipalType string
 
-@description('A cloud init file (starting with #cloud-config) as a base 64 encoded string used to perform image customization on the jump box VMs. Used for user-management in this context.')
+@description('A cloud init file (starting with #cloud-config) as a Base64 encoded string used to perform OS configuration on the VMs as part of bootstrapping. Used for network configuration in this context.')
 @minLength(100)
 param frontendCloudInitAsBase64 string
 

--- a/workload-team/main.bicep
+++ b/workload-team/main.bicep
@@ -70,7 +70,7 @@ param adminSecurityPrincipalObjectId string
 ])
 param adminSecurityPrincipalType string
 
-@description('A cloud init file (starting with #cloud-config) as a base 64 encoded string used to perform image customization on the jump box VMs. Used for user-management in this context.')
+@description('A cloud init file (starting with #cloud-config) as a Base64 encoded string used to perform OS configuration on the VMs as part of bootstrapping. Used for network configuration in this context.')
 @minLength(100)
 param frontendCloudInitAsBase64 string
 

--- a/workload-team/main.bicep
+++ b/workload-team/main.bicep
@@ -70,6 +70,10 @@ param adminSecurityPrincipalObjectId string
 ])
 param adminSecurityPrincipalType string
 
+@description('A cloud init file (starting with #cloud-config) as a base 64 encoded string used to perform image customization on the jump box VMs. Used for user-management in this context.')
+@minLength(100)
+param frontendCloudInitAsBase64 string
+
 /*** VARIABLES ***/
 
 var subComputeRgUniqueString = uniqueString('bu04a42', computeResourceGroup.id)
@@ -129,6 +133,7 @@ module deployWorkloadInfrastructure 'app-infra-stamp.bicep' = {
     subComputeRgUniqueString: subComputeRgUniqueString
     adminSecurityPrincipalObjectId: adminSecurityPrincipalObjectId
     adminSecurityPrincipalType: adminSecurityPrincipalType
+    frontendCloudInitAsBase64: frontendCloudInitAsBase64
   }
   dependsOn: [
     applySubnetsAndUdrs

--- a/workload-team/workload/frontendCloudInit.yml
+++ b/workload-team/workload/frontendCloudInit.yml
@@ -12,6 +12,8 @@ write_files:
       network:
         ethernets:
           eth0:
+            match:
+              name: eth*
             nameservers:
               search: [~.]
 runcmd:

--- a/workload-team/workload/frontendCloudInit.yml
+++ b/workload-team/workload/frontendCloudInit.yml
@@ -13,7 +13,7 @@ write_files:
         ethernets:
           eth0:
             match:
-              driver: hv_netvsc
+              name: eth*
             nameservers:
               search: [~.]
 runcmd:

--- a/workload-team/workload/frontendCloudInit.yml
+++ b/workload-team/workload/frontendCloudInit.yml
@@ -11,7 +11,7 @@ write_files:
     content: |
       network:
         ethernets:
-          alleths:
+          eth0:
             match:
               name: eth*
             nameservers:

--- a/workload-team/workload/frontendCloudInit.yml
+++ b/workload-team/workload/frontendCloudInit.yml
@@ -11,7 +11,7 @@ write_files:
     content: |
       network:
         ethernets:
-          eth0:
+          alleths:
             match:
               name: eth*
             nameservers:

--- a/workload-team/workload/frontendCloudInit.yml
+++ b/workload-team/workload/frontendCloudInit.yml
@@ -12,7 +12,7 @@ write_files:
         ethernets:
           eth0:
             nameservers:
-              search: [backend-00.iaas-ingress.contoso.com]
+              search: [~backend-00.iaas-ingress.contoso.com]
               addresses: [168.63.129.16]
 runcmd:
   - [ netplan, apply ]

--- a/workload-team/workload/frontendCloudInit.yml
+++ b/workload-team/workload/frontendCloudInit.yml
@@ -13,7 +13,7 @@ write_files:
         ethernets:
           eth0:
             match:
-              name: eth*
+              driver: hv_netvsc
             nameservers:
               search: [~.]
 runcmd:

--- a/workload-team/workload/frontendCloudInit.yml
+++ b/workload-team/workload/frontendCloudInit.yml
@@ -1,5 +1,10 @@
 #cloud-config
 write_files:
+  - path: /etc/systemd/resolved.conf
+    permissions: '0644'
+    content: |
+      [Resolve]
+      DNS=10.200.0.4
   - path: /etc/netplan/99-dns.yaml
     permissions: '0644'
     content: |
@@ -11,3 +16,4 @@ write_files:
               addresses: [168.63.129.16]
 runcmd:
   - [ netplan, apply ]
+  - [ service, systemd-resolved, restart ]

--- a/workload-team/workload/frontendCloudInit.yml
+++ b/workload-team/workload/frontendCloudInit.yml
@@ -1,12 +1,13 @@
 #cloud-config
 write_files:
-  - owner: root:root
-    path: /etc/cloud/cloud.cfg.d/99-disable-network-config.cfg
+  - path: /etc/netplan/99-dns.yaml
+    permissions: '0644'
     content: |
       network:
-         config: disabled
+        ethernets:
+          eth0:
+            nameservers:
+              search: [backend-00.iaas-ingress.contoso.com]
+              addresses: [168.63.129.16]
 runcmd:
-  - [ sed, -i, '/set-name:/a \            nameservers:', /etc/netplan/50-cloud-init.yaml ]
-  - [ sed, -i, '/nameservers:/a \                addresses: [168.63.129.16]', /etc/netplan/50-cloud-init.yaml ]
-  - [ sed, -i, '/addresses:/a \                search: [backend.iaas-ingress.contoso.com]', /etc/netplan/50-cloud-init.yaml ]
   - [ netplan, apply ]

--- a/workload-team/workload/frontendCloudInit.yml
+++ b/workload-team/workload/frontendCloudInit.yml
@@ -1,0 +1,12 @@
+#cloud-config
+write_files:
+  - owner: root:root
+    path: /etc/cloud/cloud.cfg.d/99-disable-network-config.cfg
+    content: |
+      network:
+         config: disabled
+runcmd:
+  - [ sed, -i, '/set-name:/a \            nameservers:', /etc/netplan/50-cloud-init.yaml ]
+  - [ sed, -i, '/nameservers:/a \                addresses: [168.63.129.16]', /etc/netplan/50-cloud-init.yaml ]
+  - [ sed, -i, '/addresses:/a \                search: [backend.iaas-ingress.contoso.com]', /etc/netplan/50-cloud-init.yaml ]
+  - [ netplan, apply ]

--- a/workload-team/workload/frontendCloudInit.yml
+++ b/workload-team/workload/frontendCloudInit.yml
@@ -4,7 +4,8 @@ write_files:
     permissions: '0644'
     content: |
       [Resolve]
-      DNS=10.200.0.4
+      DNS=168.63.129.16
+      Domains=~backend-00.iaas-ingress.contoso.com
   - path: /etc/netplan/99-dns.yaml
     permissions: '0644'
     content: |
@@ -12,8 +13,7 @@ write_files:
         ethernets:
           eth0:
             nameservers:
-              search: [~backend-00.iaas-ingress.contoso.com]
-              addresses: [168.63.129.16]
+              search: [~.]
 runcmd:
   - [ netplan, apply ]
   - [ service, systemd-resolved, restart ]


### PR DESCRIPTION
- change netplan configuration using cloud-init: add per domain exception for backend to resolve using Azure provided DNS
- combine Netplan with special systemd-resolved config via cloud-init  to get global dns resolution for the rest of domains
- remove TODO that resolved DNS queries from hub