### PR TITLE
RG naming

### DIFF
--- a/02-connectivity-subscription.md
+++ b/02-connectivity-subscription.md
@@ -14,7 +14,7 @@ The following resource group will be created and populated with networking resou
 
 | Name                              | Purpose                                   |
 | :-------------------------------- | :---------------------------------------- |
-| rg-plz-connectivity-regional-hubs | Contains all of your organization's regional hubs. A regional hubs include an egress firewall and Log Analytics for network logging. This is a stand-in for resources typically found in your Connectivity subscription. |
+| rg-plz-connectivity-regional-hubs-${REGION_IAAS_BASELINE} | Contains all of your organization's regional hubs. A regional hubs include an egress firewall and Log Analytics for network logging. This is a stand-in for resources typically found in your Connectivity subscription. |
 
 #### Resource group naming convention
 
@@ -47,7 +47,7 @@ The hub will be a virtual network based hub, containing common shared resources 
 
    ```bash
    # [This takes less than one minute to run.]
-   az group create -n rg-plz-connectivity-regional-hubs -l centralus
+   az group create -n rg-plz-connectivity-regional-hubs-${REGION_IAAS_BASELINE} -l ${REGION_IAAS_BASELINE}
    ```
 
 1. Create the regional network hub.
@@ -58,9 +58,9 @@ The hub will be a virtual network based hub, containing common shared resources 
 
    ```bash
    # [This takes about ten minutes to run.]
-   az deployment group create -g rg-plz-connectivity-regional-hubs -f platform-team/hub-default.bicep -p location=${REGION_IAAS_BASELINE}
+   az deployment group create -g rg-plz-connectivity-regional-hubs-${REGION_IAAS_BASELINE} -f platform-team/hub-default.bicep -p location=${REGION_IAAS_BASELINE}
 
-   export RESOURCEID_VNET_HUB_IAAS_BASELINE=$(az deployment group show -g rg-plz-connectivity-regional-hubs -n hub-default --query properties.outputs.hubVnetId.value -o tsv)
+   export RESOURCEID_VNET_HUB_IAAS_BASELINE=$(az deployment group show -g rg-plz-connectivity-regional-hubs-${REGION_IAAS_BASELINE} -n hub-default --query properties.outputs.hubVnetId.value -o tsv)
    echo RESOURCEID_VNET_HUB_IAAS_BASELINE: $RESOURCEID_VNET_HUB_IAAS_BASELINE
    ```
 

--- a/04-subscription-vending-execute.md
+++ b/04-subscription-vending-execute.md
@@ -14,7 +14,7 @@ The following resource group will be created and populated with core networking 
 
 | Name                 | Purpose                                   |
 | :------------------- | :---------------------------------------- |
-| rg-alz-bu04a42-spoke | This is a stand-in for part of your application landing zone subscription. This specifically contains the virtual network in which your architecture will reside within. |
+| rg-alz-bu04a42-spoke-${REGION_IAAS_BASELINE} | This is a stand-in for part of your application landing zone subscription. This specifically contains the virtual network in which your architecture will reside within. |
 
 #### Resource group naming convention
 

--- a/07-compute-infra.md
+++ b/07-compute-infra.md
@@ -10,7 +10,7 @@ The following resource group will be created and populated with the IaaS baselin
 
 | Name                   | Purpose                                   |
 | :--------------------- | :---------------------------------------- |
-| rg-alz-bu04a42-compute | This contains your application landing zone resources related to your infrastructure. It contains load balancing, compute, and related resources. |
+| rg-alz-bu04a42-compute-${REGION_IAAS_BASELINE} | This contains your application landing zone resources related to your infrastructure. It contains load balancing, compute, and related resources. |
 
 ### Application Gateway placement
 

--- a/09-validation.md
+++ b/09-validation.md
@@ -14,7 +14,7 @@ This section will help you to validate the workload is exposed correctly and res
 
    ```bash
    # query the Azure Application Gateway Public Ip
-   APPGW_PUBLIC_IP=$(az deployment group show -g rg-alz-bu04a42-spoke -n apply-networking --query properties.outputs.appGwPublicIpAddress.value -o tsv)
+   APPGW_PUBLIC_IP=$(az deployment group show -g rg-alz-bu04a42-spoke-${REGION_IAAS_BASELINE} -n apply-networking --query properties.outputs.appGwPublicIpAddress.value -o tsv)
    echo APPGW_PUBLIC_IP: $APPGW_PUBLIC_IP
    ```
 
@@ -52,7 +52,7 @@ Your workload is placed behind a Web Application Firewall (WAF), which has rules
 1. Observe that your request was blocked by Application Gateway's WAF rules and your workload never saw this potentially dangerous request.
 1. Blocked requests (along with other gateway data) will be visible in the attached Log Analytics workspace.
 
-   Browse to the Application Gateway in the resource group `rg-alz-bu04a42-compute` and navigate to the _Logs_ blade. Execute the following query below to show WAF logs and see that the request was rejected due to a _SQL Injection Attack_ (field _Message_).
+   Browse to the Application Gateway in the resource group `rg-alz-bu04a42-compute-${REGION_IAAS_BASELINE}` and navigate to the _Logs_ blade. Execute the following query below to show WAF logs and see that the request was rejected due to a _SQL Injection Attack_ (field _Message_).
 
    > :warning: Note that it may take a couple of minutes until the logs are transferred from the Application Gateway to the Log Analytics Workspace. So be a little patient if the query does not immediatly return results after sending the https request in the former step.
 
@@ -67,7 +67,7 @@ Your workload is placed behind a Web Application Firewall (WAF), which has rules
 Monitoring your compute infrastructure is critical, especially when you're running in production. Therefore, your virtual machines are configured with [boot diagnostics](https://learn.microsoft.com/troubleshoot/azure/virtual-machines/boot-diagnostics) and Azure Monitor and VM Insights sends sends logs and metrics to the Log Analytics Workspace deployed with your compute.
 
 ```bash
-az vm boot-diagnostics get-boot-log --ids $(az vm list -g rg-alz-bu04a42-compute --query "[0].id" -o tsv)
+az vm boot-diagnostics get-boot-log --ids $(az vm list -g rg-alz-bu04a42-compute-${REGION_IAAS_BASELINE} --query "[0].id" -o tsv)
 ```
 
 ### Steps

--- a/10-cleanup.md
+++ b/10-cleanup.md
@@ -7,7 +7,7 @@ After you are done exploring your deployed [IaaS baseline](./09-validation.md), 
 1. Obtain the Azure KeyVault resource name
 
    ```bash
-   KEYVAULT_NAME=$(az deployment group show -g rg-alz-bu04a42-compute -n deploy-workload-infrastructure --query properties.outputs.keyVaultName.value -o tsv)
+   KEYVAULT_NAME=$(az deployment group show -g rg-alz-bu04a42-compute-${REGION_IAAS_BASELINE} -n deploy-workload-infrastructure --query properties.outputs.keyVaultName.value -o tsv)
    echo KEYVAULT_NAME: $KEYVAULT_NAME
    ```
 
@@ -18,9 +18,9 @@ After you are done exploring your deployed [IaaS baseline](./09-validation.md), 
    :warning: Ensure you are using the correct subscription, and validate that the only resources that exist in these groups are ones you're okay deleting.
 
    ```bash
-   az group delete -n rg-alz-bu04a42-compute -f Microsoft.Compute/virtualMachineScaleSets
-   az group delete -n rg-alz-bu04a42-spoke
-   az group delete -n rg-plz-connectivity-regional-hubs
+   az group delete -n rg-alz-bu04a42-compute-${REGION_IAAS_BASELINE} -f Microsoft.Compute/virtualMachineScaleSets
+   az group delete -n rg-alz-bu04a42-spoke-${REGION_IAAS_BASELINE}
+   az group delete -n rg-plz-connectivity-regional-hubs-${REGION_IAAS_BASELINE}
    ```
 
 1. Purge Azure Key Vault

--- a/platform-team/subscription-vending/app-landing-zone-bu04a42.bicep
+++ b/platform-team/subscription-vending/app-landing-zone-bu04a42.bicep
@@ -7,7 +7,7 @@ targetScope = 'resourceGroup'
 param hubVnetResourceId string
 
 @description('The spokes\'s regional affinity, must be the same as the hub\'s location.')
-param location string
+param location string = resourceGroup().location
 
 /*** EXISTING HUB RESOURCES ***/
 

--- a/platform-team/subscription-vending/deploy-alz-bu04a42.bicep
+++ b/platform-team/subscription-vending/deploy-alz-bu04a42.bicep
@@ -72,13 +72,13 @@ resource regionalHubVirtualNetwork 'Microsoft.Network/virtualNetworks@2022-11-01
 
 @description('Spoke resource group. This typically would be in a dedicated subscription for the workload.')
 resource appLandingZoneSpokeResourceGroup 'Microsoft.Resources/resourceGroups@2022-09-01' = {
-  name: 'rg-alz-bu04a42-spoke'
+  name: 'rg-alz-bu04a42-spoke-${location}'
   location: location
 }
 
 @description('This is rg-alz-bu04a42-compute, which wouldn\'t technically exist at this point. We need a fake reference to it to scope Azure Policy assignments to simulate policies being applied from the Online management group.')
 resource knownFutureAppResourceGroup 'Microsoft.Resources/resourceGroups@2022-09-01' = {
-  name: 'rg-alz-bu04a42-compute'
+  name: 'rg-alz-bu04a42-compute-${location}'
   location: location
 }
 

--- a/platform-team/subscription-vending/hub-updates-bu04a42.bicep
+++ b/platform-team/subscription-vending/hub-updates-bu04a42.bicep
@@ -7,7 +7,7 @@ targetScope = 'resourceGroup'
 param spokeVirtualNetworkResourceId string
 
 @description('The existing hub\'s regional affinity.')
-param location string
+param location string = resourceGroup().location
 
 // A designator that represents a business unit id and application id
 var orgAppId = 'bu04a42'

--- a/platform-team/subscription-vending/management-group-proxy.bicep
+++ b/platform-team/subscription-vending/management-group-proxy.bicep
@@ -21,7 +21,7 @@ targetScope = 'resourceGroup'
     https://github.com/Azure/Enterprise-Scale/wiki/ALZ-Policies
 */
 
-param location string
+param location string = resourceGroup().location
 
 @description('The ID of the resource group that contains the private DNS zones. In this deployment, it\'s the hub resource group.')
 param dnsZoneResourceGroupId string

--- a/workload-team/app-infra-networking.bicep
+++ b/workload-team/app-infra-networking.bicep
@@ -7,7 +7,7 @@ targetScope = 'resourceGroup'
 param workloadLogWorkspaceResourceId string
 
 @description('The spokes\'s regional affinity, must be the same as the hub\'s location.')
-param location string
+param location string = resourceGroup().location
 
 /*** EXISTING RESOURCES ***/
 

--- a/workload-team/app-infra-shared-svcs.bicep
+++ b/workload-team/app-infra-shared-svcs.bicep
@@ -3,7 +3,7 @@ targetScope = 'resourceGroup'
 /*** PARAMETERS ***/
 
 @description('The region for IaaS resources, and supporting managed services (i.e. KeyVault, App Gateway, etc) . This needs to be the same region as the target virtual network provided.')
-param location string
+param location string = resourceGroup().location
 
 @description('A common uniquestring reference used for resources that benefit from having a unique component.')
 @maxLength(13)

--- a/workload-team/app-infra-stamp.bicep
+++ b/workload-team/app-infra-stamp.bicep
@@ -7,7 +7,7 @@ targetScope = 'resourceGroup'
 param targetVnetResourceId string
 
 @description('IaaS region. This needs to be the same region as the virtual network provided in these parameters.')
-param location string
+param location string = resourceGroup().location
 
 @description('The certificate data for Azure Application Gateway TLS termination. It is Base64 encoded.')
 @secure()
@@ -80,7 +80,7 @@ resource spokeResourceGroup 'Microsoft.Resources/resourceGroups@2022-09-01' exis
 @description('Existing resource group that has our regional hub network. This is owned by the platform team, and usually is in another subscription.')
 resource hubResourceGroup 'Microsoft.Resources/resourceGroups@2022-09-01' existing = {
   scope: subscription()
-  name: 'rg-plz-connectivity-regional-hubs'
+  name: 'rg-plz-connectivity-regional-hubs-${location}'
 }
 
 /*** EXISTING RESOURCES ***/

--- a/workload-team/main.bicep
+++ b/workload-team/main.bicep
@@ -95,7 +95,7 @@ resource landingZoneVirtualNetwork 'Microsoft.Network/virtualNetworks@2022-11-01
 
 @description('The resource group that holds most of the resources in this architecture not provided by the platform landing zone team.')
 resource computeResourceGroup 'Microsoft.Resources/resourceGroups@2022-09-01' = {
-  name: 'rg-alz-bu04a42-compute'
+  name: 'rg-alz-bu04a42-compute-${location}'
   location: location
 }
 


### PR DESCRIPTION
* Consider making the location part of the resource group's name. :white_check_mark:
* Bicep/ARM location param should default to resourceGroup().location  and no longer be provided in the az deployment group create command. :white_check_mark: